### PR TITLE
css alignment fixup

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -44,13 +44,14 @@ input[type=number] {
   justify-content: flex-end;
   gap: 1em;
 
-  width: 100%;
-  min-height: 100%;
-  margin: 0 auto;
+  width: auto;
+  height: 100%;
   position: relative;
 
-  right: 1em;
+  right: 0;
   bottom: 1em;
+
+  padding: 0 1em;
 }
 
 .chest {


### PR DESCRIPTION
- growth should be anchored to bottom right
- items should not be able to touch left side of screen
- overflow escapes on top ONLY, not top and bottom