### PR TITLE
fixup: use 3000 for whole service

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,7 +2,7 @@ name: mukchests
 services:
   node:
     type: node:16
-    scanner: false
+    port: 3000
     build:
       - npm install
     command: npm start


### PR DESCRIPTION
otherwise Lando looks at port 80 internally. fine for apache, but our app.js is running everything from 3000. Avoids the need to turn the `scanner` service off.