### PR TITLE
fix chest-click-removal count and actually remove

### DIFF
--- a/public/js/logic.js
+++ b/public/js/logic.js
@@ -30,11 +30,17 @@ $(document).ready(function(){
   });
 
   // Remove the chest you click on
-  $("#container").on("click", "div", function(){
-    $(this).hide("fast", function(){
-      $(this).remove();
-      chestCount--;
-      $("#count").val(chestCount);
-    });
+  $("#container").on("click", "div.chest-wrapper", function(){
+    $(this).hide("fast", done(event));
   });
+
+  // "on" delegated element events need a static callback function
+  function done(event) {
+    // Event is actually propagated on the .chest element
+    $(event.target).parents('div.chest-wrapper').remove();
+    chestCount--;
+    localStorage.setItem('count', chestCount);
+    $("#count").val(chestCount);
+  }
+
 });


### PR DESCRIPTION
- there's some strangeness on event targeting here
- chests with .on() listener don't trigger animation complete functions unless they are static
- actually remove the chest containers, not just display none
- count-- code wasn't working for this. now it is