### PR TITLE
Fix .on() method event handling

### DIFF
--- a/public/js/logic.js
+++ b/public/js/logic.js
@@ -43,7 +43,6 @@ $(document).ready(function(){
 
   // Remove the chest you click on
   $("#container").on("click", "div.chest-wrapper", function(e){
-    // "on" delegated element events need a static callback function
     $(this).hide("fast", done(e));
   });
 

--- a/public/js/logic.js
+++ b/public/js/logic.js
@@ -42,8 +42,9 @@ $(document).ready(function(){
   });
 
   // Remove the chest you click on
-  $("#container").on("click", "div.chest-wrapper", function(){
-    $(this).hide("fast", done(event));
+  $("#container").on("click", "div.chest-wrapper", function(e){
+    // "on" delegated element events need a static callback function
+    $(this).hide("fast", done(e));
   });
 
   // "on" delegated element events need a static callback function


### PR DESCRIPTION
- the future .on() method is weird
- we need to explicitly send the event object
- deprecation warnings aren't aware of this